### PR TITLE
Use static variable instead of INJECTED

### DIFF
--- a/src/Kaleidoscope/Qukeys.cpp
+++ b/src/Kaleidoscope/Qukeys.cpp
@@ -44,6 +44,7 @@ uint16_t Qukeys::time_limit_ = 500;
 QueueItem Qukeys::key_queue_[] = {};
 uint8_t Qukeys::key_queue_length_ = 0;
 byte Qukeys::qukey_state_[] = {};
+bool Qukeys::flushing_queue_ = false;
 
 // Empty constructor; nothing is stored at the instance level
 Qukeys::Qukeys(void) {}
@@ -130,7 +131,7 @@ void Qukeys::flushKey(bool qukey_state, uint8_t keyswitch_state) {
     handleKeyswitchEvent(keycode, row, col, IS_PRESSED | WAS_PRESSED);
 
   // Now that we're done sending the report(s), Qukeys can process events again:
-  flushing_queue_ = true;
+  flushing_queue_ = false;
 
   // Shift the queue, so key_queue[0] is always the first key that gets processed
   for (byte i = 0; i < key_queue_length_; i++) {

--- a/src/Kaleidoscope/Qukeys.h
+++ b/src/Kaleidoscope/Qukeys.h
@@ -92,6 +92,7 @@ class Qukeys : public KaleidoscopePlugin {
   static uint16_t time_limit_;
   static QueueItem key_queue_[QUKEYS_QUEUE_MAX];
   static uint8_t key_queue_length_;
+  static bool flushing_queue_;
 
   // Qukey state bitfield
   static uint8_t qukey_state_[(TOTAL_KEYS) / 8 + ((TOTAL_KEYS) % 8 ? 1 : 0)];


### PR DESCRIPTION
In order to prevent loops, avoid processing our own injected key presses, and also allow other plugins to process those keypresses, we need to use a static (class) variable (`flushing_queue_`) instead of the `INJECTED` keyswitch state flag, because other plugins will ignore events that we want them to process if we use `INJECTED`.

This depends on keyboardio/Kaleidoscope#262