### PR TITLE
Implemented a grace period for qukey release

### DIFF
--- a/examples/Qukeys/Qukeys.ino
+++ b/examples/Qukeys/Qukeys.ino
@@ -50,6 +50,7 @@ void setup() {
     kaleidoscope::Qukey(0, 2, 4, Key_LeftShift)     // F/shift
   )
   Qukeys.setTimeout(200);
+  Qukeys.setGracePeriod(20);
 
   // To toggle Qukeys off and on, we use a macro
   Kaleidoscope.use(&Macros);

--- a/src/Kaleidoscope/Qukeys.cpp
+++ b/src/Kaleidoscope/Qukeys.cpp
@@ -246,13 +246,13 @@ void Qukeys::preReportHook(void) {
   // If the qukey has been held longer than the time limit, set its
   // state to the alternate keycode and add it to the report
   uint16_t current_time = (uint16_t)millis();
-  for (byte i = key_queue_length - 1; i >= 0; --i) {
-    uint16_t grace_time = current_time - key_queue_[i].start_time;
+  for (byte i = key_queue_length_; i > 0; --i) {
+    uint16_t grace_time = current_time - key_queue_[i - 1].start_time;
     if (grace_time > 0)
       continue;
     // We've found a released qukey that may still be in the grace period
     if ((grace_time + QUKEYS_GRACE_TIME_OFFSET) > grace_period_) {
-      flushQueue(i);
+      flushQueue(i - 1);
       // We need to break out of the for loop here, because after calling
       // flushQueue(), the queue is no longer valid
       break;

--- a/src/Kaleidoscope/Qukeys.cpp
+++ b/src/Kaleidoscope/Qukeys.cpp
@@ -248,10 +248,10 @@ void Qukeys::preReportHook(void) {
   uint16_t current_time = (uint16_t)millis();
   for (byte i = key_queue_length - 1; i >= 0; --i) {
     uint16_t grace_time = current_time - key_queue_[i].start_time;
-    if ((current_time - key_queue_[i].start_time) > 0)
+    if (grace_time > 0)
       continue;
     // We've found a released qukey that may still be in the grace period
-    if ((current_time - key_queue_[i].start_time - QUKEYS_GRACE_TIME_OFFSET) > grace_period_) {
+    if ((grace_time + QUKEYS_GRACE_TIME_OFFSET) > grace_period_) {
       flushQueue(i);
       // We need to break out of the for loop here, because after calling
       // flushQueue(), the queue is no longer valid

--- a/src/Kaleidoscope/Qukeys.cpp
+++ b/src/Kaleidoscope/Qukeys.cpp
@@ -246,18 +246,16 @@ void Qukeys::preReportHook(void) {
   // If the qukey has been held longer than the time limit, set its
   // state to the alternate keycode and add it to the report
   uint16_t current_time = (uint16_t)millis();
-  for (byte i = 0; i < key_queue_length_; ++i) {
+  for (byte i = key_queue_length - 1; i >= 0; --i) {
     uint16_t grace_time = current_time - key_queue_[i].start_time;
     if ((current_time - key_queue_[i].start_time) > 0)
       continue;
     // We've found a released qukey that may still be in the grace period
     if ((current_time - key_queue_[i].start_time - QUKEYS_GRACE_TIME_OFFSET) > grace_period_) {
       flushQueue(i);
-      // need to break out of the for loop here. It's not perfect, but the
-      // chances of getting two qukeys released simultaneously is quite small
+      // We need to break out of the for loop here, because after calling
+      // flushQueue(), the queue is no longer valid
       break;
-      // Alternatively, we could search the queue in the opposite direction, and
-      // that would solve the problem!
     }
   }
   while (key_queue_length_ > 0) {

--- a/src/Kaleidoscope/Qukeys.h
+++ b/src/Kaleidoscope/Qukeys.h
@@ -83,6 +83,9 @@ class Qukeys : public KaleidoscopePlugin {
   static void setTimeout(uint16_t time_limit) {
     time_limit_ = time_limit;
   }
+  static void setGracePeriod(uint8_t grace_period) {
+    grace_period_ = grace_period; // maybe check for sensible values?
+  }
 
   static Qukey * qukeys;
   static uint8_t qukeys_count;
@@ -90,6 +93,7 @@ class Qukeys : public KaleidoscopePlugin {
  private:
   static bool active_;
   static uint16_t time_limit_;
+  static uint8_t grace_period_; // shouldn't be more that 25ms
   static QueueItem key_queue_[QUKEYS_QUEUE_MAX];
   static uint8_t key_queue_length_;
   static bool flushing_queue_;

--- a/src/Kaleidoscope/Qukeys.h
+++ b/src/Kaleidoscope/Qukeys.h
@@ -57,7 +57,7 @@ struct Qukey {
 // Data structure for an entry in the key_queue
 struct QueueItem {
   uint8_t addr;        // keyswitch coordinates
-  uint16_t start_time; // time a queued key was pressed
+  int16_t start_time; // time a queued key was pressed
 };
 
 // The plugin itself
@@ -80,7 +80,7 @@ class Qukeys : public KaleidoscopePlugin {
   static void toggle(void) {
     active_ = !active_;
   }
-  static void setTimeout(uint16_t time_limit) {
+  static void setTimeout(int16_t time_limit) {
     time_limit_ = time_limit;
   }
   static void setGracePeriod(uint8_t grace_period) {
@@ -92,7 +92,7 @@ class Qukeys : public KaleidoscopePlugin {
 
  private:
   static bool active_;
-  static uint16_t time_limit_;
+  static int16_t time_limit_;
   static uint8_t grace_period_; // shouldn't be more that 25ms
   static QueueItem key_queue_[QUKEYS_QUEUE_MAX];
   static uint8_t key_queue_length_;


### PR DESCRIPTION
If a qukey and a key it's meant to be used in combination with (as a modifier, most likely) are released simultaneously, there's a race condition. To make it more reliable for people who release their modifiers at the same time as the modified keys, a grace period is used, so the qukey doesn't get immediately flushed from the queue, but instead waits some (small) interval before deciding. If the other key is released during that interval, everything proceeds as normal, otherwise we flush the qukey with its primary state.
