### PR TITLE
Added support for DualUse keys defined in keymap

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -1,0 +1,6 @@
+--style=google
+--unpad-paren
+--pad-header
+--pad-oper
+--indent-classes
+--indent=spaces=2

--- a/README.md
+++ b/README.md
@@ -58,6 +58,15 @@ likely to generate errors and out-of-order events.
   [example](https://github.com/gedankenlab/Kaleidoscope-Qukeys/blob/master/examples/Qukeys/Qukeys.ino)
   for a way to turn `Qukeys` on and off, using Kaleidoscope-Macros
 
+### DualUse key definitions
+
+In addition to normal `Qukeys` described above, Kaleidoscope-Qukeys also treats
+DualUse keys in the keymap as `Qukeys`. See [the Kaleidoscope-DualUse
+documentation](https://github.com/keyboardio/Kaleidoscope-DualUse#keymap-markup)
+for a thorough description of how to define DualUse keys. This makes `Qukeys` a
+drop-in replacement for the `DualUse` plugin, without the need to edit the
+keymap.
+
 
 ## Design & Implementation
 

--- a/examples/Qukeys/Qukeys.ino
+++ b/examples/Qukeys/Qukeys.ino
@@ -10,21 +10,41 @@ enum { MACRO_TOGGLE_QUKEYS };
 KEYMAPS(
   [0] = KEYMAP_STACKED
   (
-    Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
-    Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
-    Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
-    Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
+      Key_NoKey,    Key_1, Key_2, Key_3, Key_4, Key_5, Key_NoKey,
+      Key_Backtick, Key_Q, Key_W, Key_E, Key_R, Key_T, Key_Tab,
+      Key_PageUp,   Key_A, Key_S, Key_D, Key_F, Key_G,
+      Key_PageDown, Key_Z, Key_X, Key_C, Key_V, Key_B, Key_Escape,
 
-    Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
-    ___,
+      Key_LeftControl, Key_Backspace, Key_LeftGui, Key_LeftShift,
+      Key_Q,
 
-    M(MACRO_TOGGLE_QUKEYS), Key_6, Key_7, Key_8,     Key_9,      Key_0,         Key_skip,
-    Key_Enter,              Key_Y, Key_U, Key_I,     Key_O,      Key_P,         Key_Equals,
-                            Key_H, Key_J, Key_K,     Key_L,      Key_Semicolon, Key_Quote,
-    Key_skip,               Key_N, Key_M, Key_Comma, Key_Period, Key_Slash,     Key_Minus,
+      M(MACRO_TOGGLE_QUKEYS), Key_6, Key_7,    Key_8,     Key_9,      Key_0,            Key_skip,
+      Key_Enter,              Key_Y, Key_U,    Key_I,     Key_O,      Key_P,            Key_Equals,
+                              Key_H, SFT_T(J), CTL_T(K),  ALT_T(L),   GUI_T(Semicolon), Key_Quote,
+      Key_skip,               Key_N, Key_M,    Key_Comma, Key_Period, Key_Slash,        Key_Minus,
 
-    Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
-    ___),
+      Key_RightShift, Key_RightAlt, Key_Spacebar, Key_RightControl,
+      LT(1,E)
+   ),
+  [1] = KEYMAP_STACKED
+  (
+      ___,   Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+
+      Key_1, Key_2, Key_3, Key_4,
+      ___,
+
+
+      ___,   Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F,
+      Key_A, Key_B, Key_C, Key_D, Key_E, Key_F, Key_G,
+
+      Key_1, Key_2, Key_3, Key_4,
+      ___
+   ),
 )
 // *INDENT-ON*
 
@@ -47,7 +67,8 @@ void setup() {
     kaleidoscope::Qukey(0, 2, 1, Key_LeftGui),      // A/cmd
     kaleidoscope::Qukey(0, 2, 2, Key_LeftAlt),      // S/alt
     kaleidoscope::Qukey(0, 2, 3, Key_LeftControl),  // D/ctrl
-    kaleidoscope::Qukey(0, 2, 4, Key_LeftShift)     // F/shift
+    kaleidoscope::Qukey(0, 2, 4, Key_LeftShift),    // F/shift
+    kaleidoscope::Qukey(0, 3, 6, ShiftToLayer(1))   // Q/layer-shift (on `fn`)
   )
   Qukeys.setTimeout(200);
 

--- a/src/Kaleidoscope/Qukeys.h
+++ b/src/Kaleidoscope/Qukeys.h
@@ -20,6 +20,7 @@
 
 #include <Kaleidoscope.h>
 #include <addr.h>
+#include <Kaleidoscope-Ranges.h>
 
 // Maximum length of the pending queue
 #define QUKEYS_QUEUE_MAX 8
@@ -40,6 +41,16 @@
 #define QUKEY_NOT_FOUND -1
 // Wildcard value; this matches any layer
 #define QUKEY_ALL_LAYERS -1
+
+#define MT(mod, key) (Key) { \
+    .raw = kaleidoscope::ranges::DUM_FIRST + \
+      (((Key_ ## mod).keyCode - Key_LeftControl.keyCode) << 8) + (Key_ ## key).keyCode }
+#define SFT_T(key) MT(LeftShift, key)
+#define CTL_T(key) MT(LeftControl, key)
+#define ALT_T(key) MT(LeftAlt, key)
+#define GUI_T(key) MT(LeftGui, key)
+
+#define LT(layer, key) (Key) { .raw = kaleidoscope::ranges::DUL_FIRST + (layer << 8) + (Key_ ## key).keyCode }
 
 namespace kaleidoscope {
 


### PR DESCRIPTION
This allows users to define DualUse keys (see [Kaleidoscope-DualUse](https://github.com/keyboardio/Kaleidoscope-DualUse)) in the keymap, and have Qukeys handle them instead. There are a few limitations:

- Unlike full-fledged Qukeys, the alternate keycode for a DualUse key is always a modifier or (temporary) layer switch, and the primary keycode is limited to basic keycodes without modifiers.
- Qukeys is now incompatible with DualUse (not that you would want to use both of them simultaneously, anyway).

Before merging this, I need to update the documentation.