### PR TITLE
Ignore keyswitch events with out-of-bounds addresses

### DIFF
--- a/src/Kaleidoscope/Qukeys.cpp
+++ b/src/Kaleidoscope/Qukeys.cpp
@@ -215,6 +215,10 @@ void Qukeys::flushQueue() {
 
 Key Qukeys::keyScanHook(Key mapped_key, byte row, byte col, uint8_t key_state) {
 
+  // If key_addr is not a physical key, ignore it; some other plugin injected it
+  if (row >= ROWS || col >= COLS)
+    return mapped_key;
+
   // If Qukeys is turned off, continue to next plugin
   if (!active_)
     return getDualUsePrimaryKey(mapped_key);


### PR DESCRIPTION
Any keyswitch events without real physical addresses were injected by other plugins and should not be processed by Qukeys. There was an interaction with OneShot that prevented the two plugins from working together because OneShot sends events with a (row, col) address of `UNKNOWN_KEYSWITCH_LOCATION` (i.e. 255, 255). This meant that if a OneShot modifier was on when a Qukey was pressed, it would fill up the queue with bogus-address versions of the Qukey, which would then get flushed in the primary state, cancelling the OneShot and producing an un-modified, repeating primary keycode, causing both plugins to fail.